### PR TITLE
Add webbrowser to backend

### DIFF
--- a/backend/src/grapycal/app.py
+++ b/backend/src/grapycal/app.py
@@ -1,16 +1,14 @@
 import contextlib
 import os
-import shutil
 import signal
 import sys
-from typing import Any, Callable, Dict
 import subprocess
 
 import grapycal
-from .utils.file import get_direct_sub_folders
 import termcolor
 import time
 from .utils import usersettings
+
 
 class GrapycalApp:
     """
@@ -18,11 +16,11 @@ class GrapycalApp:
 
     :param usersettings.Settings config: the configuration for server
     """
-    def __init__(self, config:usersettings.Settings) -> None:
-        self._config = config
-        if not config['path'].endswith('.grapycal'):
-            config['path'] += '.grapycal'
 
+    def __init__(self, config: usersettings.Settings) -> None:
+        self._config = config
+        if not config["path"].endswith(".grapycal"):
+            config["path"] += ".grapycal"
 
     def run(self) -> None:
         """
@@ -30,96 +28,127 @@ class GrapycalApp:
         """
         version = grapycal.__version__
         print(
-            termcolor.colored(r'''
+            termcolor.colored(
+                r"""
                ______                                  __
               / ____/________ _____  __  ___________ _/ /
-             / / __/ ___/ __ `/ __ \/ / / / ___/ __ `/ / 
-            / /_/ / /  / /_/ / /_/ / /_/ / /__/ /_/ / /  
-            \____/_/   \__,_/ .___/\__, /\___/\__,_/_/   
+             / / __/ ___/ __ `/ __ \/ / / / ___/ __ `/ /
+            / /_/ / /  / /_/ / /_/ / /_/ / /__/ /_/ / /
+            \____/_/   \__,_/ .___/\__, /\___/\__,_/_/
                            /_/    /____/
-                                           ''','red') + termcolor.colored('v'+version, 'white'))
+                                           """,
+                "red",
+            )
+            + termcolor.colored("v" + version, "white")
+        )
         print()
 
-        #TODO: Support multiple workspaces
-        #TODO: Websocket multiplexing
+        # TODO: Support multiple workspaces
+        # TODO: Websocket multiplexing
 
         workspace = None
         http_server = None
         # Here simply start one workspace in background
-            
+
         # Start webpage server
-        if not self._config['no_http']:
-            webpage_path = os.path.join(os.path.dirname(__file__),'webpage')
-            print(f'Strating webpage server at localhost:{self._config["http_port"]} from {webpage_path}...')
-            http_server = subprocess.Popen([sys.executable,'-m', 'http.server',str(self._config["http_port"])],
-                                start_new_session=True,cwd=webpage_path,
-                                stdout=subprocess.DEVNULL
-                                )
+        if not self._config["no_http"]:
+            webpage_path = os.path.join(os.path.dirname(__file__), "webpage")
+            print(
+                f'Strating webpage server at localhost:{self._config["http_port"]} from {webpage_path}...'
+            )
+            http_server = subprocess.Popen(
+                [sys.executable, "-m", "http.server", str(self._config["http_port"])],
+                start_new_session=True,
+                cwd=webpage_path,
+                stdout=subprocess.DEVNULL,
+            )
 
-        while True: # Restart workspace when it exits. Convenient for development
+            import threading
+            import webbrowser
 
+            threading.Timer(
+                2.5,
+                lambda: webbrowser.open(
+                    f'http://localhost:{self._config["http_port"]}'
+                ),
+            ).start()
+            print(f'Start browser at URL: http://localhost:{self._config["http_port"]}')
+
+        while True:  # Restart workspace when it exits. Convenient for development
             with self._run_workspace() as workspace:
                 self._waitForWorkspace(workspace)
 
-            restart = self._config['restart'] and workspace.poll() == 0
+            restart = self._config["restart"] and workspace.poll() == 0
 
-            exit_message_file = f'grapycal_exit_message_{workspace.pid}'
+            exit_message_file = f"grapycal_exit_message_{workspace.pid}"
             if os.path.exists(exit_message_file):
-                with open(exit_message_file,'r') as f:
+                with open(exit_message_file, "r") as f:
                     exit_message = f.read()
                 os.remove(exit_message_file)
-            
-                for line in exit_message.split('\n'):
-                    if line == '':
+
+                for line in exit_message.split("\n"):
+                    if line == "":
                         continue
-                    op, msg = line.split(' ',1)
-                    if op == 'open':
+                    op, msg = line.split(" ", 1)
+                    if op == "open":
                         # User wants to open a specific workspace
-                        self._config['path'] = msg
+                        self._config["path"] = msg
                         self._config.save_settings()
                         restart = True
 
             if not restart:
                 break
 
-        print('Stopping http server...')
+        print("Stopping http server...")
         if http_server:
             http_server.send_signal(signal.SIGTERM)
             http_server.wait()
-        print('Grapycal app terminated')
+        print("Grapycal app terminated")
         return
-    
 
     @contextlib.contextmanager
     def _run_workspace(self):
         """
         Run a workspace. Ensure that the workspace is terminated when the context is exited.
         """
-        print(f'Starting workspace {self._config["path"]} at {self._config["host"]}:{self._config["port"]}...')
-    
-        workspace = subprocess.Popen([sys.executable,'-m', 'grapycal.core.workspace',
-            '--port', str(self._config['port']),
-            '--host', self._config['host'],
-            '--path', self._config['path'],
-            ],start_new_session=True)
+        print(
+            f'Starting workspace {self._config["path"]} at {self._config["host"]}:{self._config["port"]}...'
+        )
+
+        workspace = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "grapycal.core.workspace",
+                "--port",
+                str(self._config["port"]),
+                "--host",
+                self._config["host"],
+                "--path",
+                self._config["path"],
+            ],
+            start_new_session=True,
+        )
         try:
             yield workspace
         finally:
             workspace.send_signal(signal.SIGTERM)
             workspace.wait()
 
-    def _waitForWorkspace(self,workspace:subprocess.Popen):
+    def _waitForWorkspace(self, workspace: subprocess.Popen):
         while True:
             try:
                 time.sleep(3)
             except KeyboardInterrupt:
-                print('Shutting down Grapycal server will force kill all workspaces. Press Ctrl+C again to confirm.')
+                print(
+                    "Shutting down Grapycal server will force kill all workspaces. Press Ctrl+C again to confirm."
+                )
                 try:
                     time.sleep(3)
                 except KeyboardInterrupt:
                     return
                 else:
-                    print('Resumed')
+                    print("Resumed")
             if workspace.poll() is not None:
-                print('Workspace exited with code',workspace.poll())
+                print("Workspace exited with code", workspace.poll())
                 return

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "grapycal-client",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "grapycal-client",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sentry/node": "^7.85.0",
@@ -23,7 +23,7 @@
         "ts-loader": "^9.4.2",
         "typescript": "^4.9.5",
         "webpack": "^5.75.0",
-        "webpack-cli": "^5.0.1",
+        "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^4.11.1"
       }
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "ts-loader": "^9.4.2",
     "typescript": "^4.9.5",
     "webpack": "^5.75.0",
-    "webpack-cli": "^5.0.1",
+    "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^4.11.1"
   },
   "scripts": {


### PR DESCRIPTION
Import ```webbrowser```. When a user executes ```grapycal```, it will open the web page automatically.

![grapycal_demo](https://github.com/Grapycal/Grapycal/assets/75301735/5b15388b-7666-427e-8383-6ffb7b4c8dd8)
