### PR TITLE
Simplify node definition API

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -21,7 +21,7 @@ include = ["src/grapycal/webpage/**/*"] # Have to explicitly include here becaus
 
 [tool.poetry.dependencies]
 python = "^3.11"
-objectsync = ">=0.8.3"
+objectsync = ">=0.9.1"
 pyyaml = "^6.0"
 dacite = "^1.8.1"
 usersettings = "^1.1.5"

--- a/backend/src/grapycal/core/workspace.py
+++ b/backend/src/grapycal/core/workspace.py
@@ -225,6 +225,7 @@ class Workspace:
 
         for extension_name in data['extensions']:
             self._extention_manager.create_preview_nodes(extension_name)
+            self._extention_manager._instantiate_singletons(extension_name)
 
         self._objectsync.clear_history_inclusive()
 

--- a/backend/src/grapycal/sobjects/editor.py
+++ b/backend/src/grapycal/sobjects/editor.py
@@ -112,7 +112,7 @@ class Editor(SObject):
                 node = self.add_child_s(obj.type,id=new_node_id)
                 assert isinstance(node,Node), f'Expected node, got {node}'
                 node.old_node_info = NodeInfo(obj)
-                node.restore_from_version('',node.old_node_info)
+                node._restore('',node.old_node_info)
             except Exception:
                 logger.warning(f'Failed to restore {obj.type} {obj.id}',exc_info=True)
                 if self._server.has_object(new_node_id):

--- a/backend/src/grapycal/sobjects/editor.py
+++ b/backend/src/grapycal/sobjects/editor.py
@@ -109,7 +109,7 @@ class Editor(SObject):
             # The node may fail to create when the restore() method is called when pasting, and it should not be treated as an error.
             # For example, copy and paste a node that should be unique.
             try:
-                node = self.add_child_s(obj.type,id=new_node_id)
+                node = self.add_child_s(obj.type,id=new_node_id,is_new=False)
                 assert isinstance(node,Node), f'Expected node, got {node}'
                 node.old_node_info = NodeInfo(obj)
                 node._restore('',node.old_node_info)

--- a/backend/src/grapycal/sobjects/port.py
+++ b/backend/src/grapycal/sobjects/port.py
@@ -1,7 +1,7 @@
 import abc
 from hmac import new
 from msilib import Control
-from typing import TYPE_CHECKING, Any, List
+from typing import TYPE_CHECKING, Any, List, Literal
 import typing
 from grapycal.sobjects.controls.control import ValuedControl
 from grapycal.sobjects.controls.nullControl import NullControl

--- a/backend/src/grapycal/sobjects/port.py
+++ b/backend/src/grapycal/sobjects/port.py
@@ -1,4 +1,5 @@
 import abc
+from hmac import new
 from msilib import Control
 from typing import TYPE_CHECKING, Any, List
 import typing
@@ -58,7 +59,8 @@ class InputPort(Port, typing.Generic[T]):
                 i+=1
                 control_name = f'Control{i}'
 
-        self.default_control = self.add_child(control_type, **control_kwargs)
+        new_control_id = f'{self.node.get_id()}_c_{control_name}'
+        self.default_control = self.add_child(control_type, id=new_control_id, **control_kwargs)
         self.node.controls.add(control_name,self.default_control)
 
         # this topic affects css

--- a/backend/src/grapycal/sobjects/workspaceObject.py
+++ b/backend/src/grapycal/sobjects/workspaceObject.py
@@ -54,53 +54,52 @@ class WorkspaceObject(SObject):
         # read by frontend
         self.add_attribute('main_editor',ObjTopic).set(self.main_editor)
 
-        self._server.on('delete',self._delete_callback,is_stateful=False)
+    # delete functionallity is moved to editor.py
+    # def _delete_callback(self,ids):
+    #     nodes:set[Node] = set()
+    #     edges:set[Edge] = set()
+    #     for id in ids:
+    #         obj = self._server.get_object(id)
+    #         match obj:
+    #             case Node():
+    #                 nodes.add(obj)
+    #             case Edge():
+    #                 edges.add(obj)
 
-    def _delete_callback(self,ids):
-        nodes:set[Node] = set()
-        edges:set[Edge] = set()
-        for id in ids:
-            obj = self._server.get_object(id)
-            match obj:
-                case Node():
-                    nodes.add(obj)
-                case Edge():
-                    edges.add(obj)
+    #     for node in nodes:
+    #         for port in node.in_ports.get() + node.out_ports.get():
+    #             for edge in port.edges:
+    #                 edges.add(edge)
 
-        for node in nodes:
-            for port in node.in_ports.get() + node.out_ports.get():
-                for edge in port.edges:
-                    edges.add(edge)
+    #     # this happens when the previous delete message are still flying to the client      
+    #     for edge in edges:
+    #         if edge.is_destroyed():
+    #             raise Exception(f'Edge {edge} is already destroyed')
+    #     for node in nodes:
+    #         if node.is_destroyed():
+    #             raise Exception(f'Node {node} is already destroyed')
 
-        # this happens when the previous delete message are still flying to the client      
-        for edge in edges:
-            if edge.is_destroyed():
-                raise Exception(f'Edge {edge} is already destroyed')
-        for node in nodes:
-            if node.is_destroyed():
-                raise Exception(f'Node {node} is already destroyed')
+    #     for edge in edges:
+    #         edge.remove()
+    #     for node in nodes:
+    #         node.remove()
 
-        for edge in edges:
-            edge.remove()
-        for node in nodes:
-            node.remove()
-
-        # logger.info(f'Deleted {len(nodes)} nodes and {len(edges)} edges')
-        # TODO: deleting nodes may need thread locking
-        if len(nodes) == 0 and len(edges) == 0:
-            return
-        msg = 'Deleted '
-        if len(nodes) > 0:
-            msg += f'{len(nodes)} node'
-            if len(nodes) > 1:
-                msg += 's' # english is hard :(
-        if len(edges) > 0:
-            if len(nodes) > 0:
-                msg += ' and '
-            msg += f'{len(edges)} edge'
-            if len(edges) > 1:
-                msg += 's'
-        logger.info(msg)
+    #     # logger.info(f'Deleted {len(nodes)} nodes and {len(edges)} edges')
+    #     # TODO: deleting nodes may need thread locking
+    #     if len(nodes) == 0 and len(edges) == 0:
+    #         return
+    #     msg = 'Deleted '
+    #     if len(nodes) > 0:
+    #         msg += f'{len(nodes)} node'
+    #         if len(nodes) > 1:
+    #             msg += 's' # english is hard :(
+    #     if len(edges) > 0:
+    #         if len(nodes) > 0:
+    #             msg += ' and '
+    #         msg += f'{len(edges)} edge'
+    #         if len(edges) > 1:
+    #             msg += 's'
+    #     logger.info(msg)
 
 class WebcamStream(SObject):
     frontend_type = 'WebcamStream'

--- a/backend/src/grapycal/utils/io.py
+++ b/backend/src/grapycal/utils/io.py
@@ -109,7 +109,7 @@ def read_workspace(path,metadata_only=False) -> Tuple[str,Any,Any]:
 
     with open_func() as f:
 
-        # DEPRECATED: v0.9.0 and before has no version number and metadata
+        # DEPRECATED from v0.10.0: v0.9.0 and before has no version number and metadata
         try:
             version = f.readline().strip()
             metadata = json.loads(f.readline())

--- a/extensions/grapycal_builtin/grapycal_builtin/container/__init__.py
+++ b/extensions/grapycal_builtin/grapycal_builtin/container/__init__.py
@@ -11,8 +11,6 @@ class ListNode(Node):
         self.set_port = self.add_in_port('set')
         self.append_port = self.add_in_port('append')
         self.get_port = self.add_out_port('get')
-
-    def init_node(self):
         self.data = []
 
     def edge_activated(self, edge: Edge, port: InputPort):

--- a/extensions/grapycal_builtin/grapycal_builtin/data/__init__.py
+++ b/extensions/grapycal_builtin/grapycal_builtin/data/__init__.py
@@ -30,9 +30,6 @@ class VariableNode(SourceNode):
         self.label.set('Variable')
         self.shape.set('simple')
         self.css_classes.append('fit-content')
-
-    def init_node(self):
-        super().init_node()
         self.value = None
         self.has_value = False
 
@@ -73,8 +70,6 @@ class SplitNode(Node):
         self.shape.set('normal')
         self.keys = self.add_attribute('keys', ListTopic, editor_type='list')
         self.key_mode = self.add_attribute('key mode', StringTopic, 'string', editor_type='options', options=['string','eval']) 
-
-    def init_node(self):
         self.keys.on_insert.add_auto(self.add_key)
         self.keys.on_pop.add_auto(self.remove_key)
 

--- a/extensions/grapycal_builtin/grapycal_builtin/function/__init__.py
+++ b/extensions/grapycal_builtin/grapycal_builtin/function/__init__.py
@@ -23,7 +23,7 @@ class LambdaNode(Node):
     def build_node(self):
         self.label.set('Lambda')
         self.shape.set('normal')
-        self.text_controls = self.add_attribute('text_controls',ObjDictTopic[TextControl])
+        self.text_controls = self.add_attribute('text_controls',ObjDictTopic[TextControl],restore_from=False)
 
         self.input_args = self.add_attribute('input_args',ListTopic,editor_type='list')
         self.outputs = self.add_attribute('outputs',ListTopic,editor_type='list')
@@ -40,16 +40,9 @@ class LambdaNode(Node):
         self.outputs.on_insert.add_auto(self.on_output_added)
         self.outputs.on_pop.add_auto(self.on_output_removed)
 
-        if self.is_new:
-            self.outputs.insert('')
-            self.text_controls[''].text.set('x')
-
-    def restore_from_version(self, version, old: NodeInfo):
-        super().restore_from_version(version, old)
-        self.input_args.set(old['input_args'])
-        self.outputs.set(old['outputs'])
-        for out_name in old['outputs']:
-            self.text_controls[out_name].text.set(old.controls[out_name]['text'])
+        # if self.is_new:
+        #     self.outputs.insert('')
+        #     self.text_controls[''].text.set('x')
     
     def on_input_arg_added(self, arg_name, position):# currently only support adding to the end
         self.add_in_port(arg_name,1,display_name = arg_name)

--- a/extensions/grapycal_builtin/grapycal_builtin/function/__init__.py
+++ b/extensions/grapycal_builtin/grapycal_builtin/function/__init__.py
@@ -20,7 +20,7 @@ class LambdaNode(Node):
         
     '''
     category = 'function'
-    def build_node(self):
+    def create(self):
         self.label.set('Lambda')
         self.shape.set('normal')
         self.text_controls = self.add_attribute('text_controls',ObjDictTopic[TextControl],restore_from=False)

--- a/extensions/grapycal_builtin/grapycal_builtin/function/__init__.py
+++ b/extensions/grapycal_builtin/grapycal_builtin/function/__init__.py
@@ -29,7 +29,7 @@ class LambdaNode(Node):
         self.outputs = self.add_attribute('outputs',ListTopic,editor_type='list')
         self.css_classes.append('fit-content')
 
-    def init_node(self):
+
         self.input_args.on_insert.add_auto(self.on_input_arg_added)
         self.input_args.on_pop.add_auto(self.on_input_arg_removed)
 

--- a/extensions/grapycal_builtin/grapycal_builtin/interaction/__init__.py
+++ b/extensions/grapycal_builtin/grapycal_builtin/interaction/__init__.py
@@ -47,7 +47,7 @@ class WebcamNode(Node):
         super().restore_from_version(version, old)
         self.restore_attributes('format')
 
-    def init_node(self):
+
         if self.is_preview.get():
             return
         self.webcam = self.workspace.webcam

--- a/extensions/grapycal_builtin/grapycal_builtin/interaction/execNode.py
+++ b/extensions/grapycal_builtin/grapycal_builtin/interaction/execNode.py
@@ -54,8 +54,6 @@ class ExecNode(SourceNode):
         self.print_last_expr = self.add_attribute('print last expr',StringTopic,editor_type='options',options=['yes','no'],init_value='yes')
         self.icon_path.set('python')
 
-    def init_node(self):
-        super().init_node()
         self.inputs.on_insert.add_auto(self.add_input)
         self.inputs.on_pop.add_auto(self.pop_input)
         self.outputs.on_insert.add_auto(self.add_output)

--- a/extensions/grapycal_builtin/grapycal_builtin/interaction/imagePasteNode.py
+++ b/extensions/grapycal_builtin/grapycal_builtin/interaction/imagePasteNode.py
@@ -52,8 +52,8 @@ class ImagePasteNode(SourceNode):
         self.out_port = self.add_out_port("img")
         self.icon_path.set("image")
 
-    def init_node(self):
-        super().init_node()
+
+        
         self.format.add_validator(self.format_validator)
 
     def restore_from_version(self, version: str, old: NodeInfo):
@@ -398,8 +398,8 @@ class LinePlotNode(Node):
             options=["from 0", "continue"],
         )
 
-    def init_node(self):
-        super().init_node()
+
+        
         self.x_coord = [0]
         self.line_plot.lines.on_insert.add_auto(self.add_line)
         self.line_plot.lines.on_pop.add_auto(self.remove_line)

--- a/extensions/grapycal_builtin/grapycal_builtin/procedural/__init__.py
+++ b/extensions/grapycal_builtin/grapycal_builtin/procedural/__init__.py
@@ -23,7 +23,7 @@ class InPortalNode(Node):
         self.out_port = self.add_out_port('then',display_name='')
         self.css_classes.append('fit-content')
     
-    def init_node(self):
+
         PortalManager.ins.append(self.name.get(),self)
         self.name.on_set2.add_manual(self.on_name_set)
 
@@ -65,7 +65,7 @@ class OutPortalNode(Node):
         self.out_port = self.add_out_port('do',display_name='')
         self.css_classes.append('fit-content')
     
-    def init_node(self):
+
         PortalManager.outs.append(self.name.get(),self)
         self.name.on_set2.add_manual(self.on_name_set)
 

--- a/extensions/grapycal_builtin/grapycal_builtin/procedural/forNode.py
+++ b/extensions/grapycal_builtin/grapycal_builtin/procedural/forNode.py
@@ -20,8 +20,8 @@ class ForNode(Node):
         self.label.set('For')
         self.shape.set('simple')
 
-    def init_node(self):
-        super().init_node()
+
+        
         self.iterator:Iterable|None = None
 
     def edge_activated(self, edge: Edge, port: InputPort):
@@ -59,8 +59,8 @@ class RepeatNode(SourceNode):
         self.shape.set('simple')
         self.times = self.add_attribute('times',IntTopic,editor_type='int',init_value=10)
 
-    def init_node(self):
-        super().init_node()
+
+        
         self.iterator:Iterable|None = None
         self.times.on_set += lambda times: self.label.set(f'Repeat {times} times')
 

--- a/extensions/grapycal_builtin/grapycal_builtin/procedural/funcDef.py
+++ b/extensions/grapycal_builtin/grapycal_builtin/procedural/funcDef.py
@@ -47,7 +47,7 @@ class FuncCallNode(Node):
         self.shape.set('normal')
         self.func_name = self.add_attribute('func_name',StringTopic,editor_type='text')
 
-    def init_node(self):
+
         FuncDefManager.calls.append(self.func_name.get(),self)
         self.func_name.on_set2.add_manual(self.on_func_name_changed)
         self.func_name.on_set.add_auto(self.on_func_name_changed_auto)
@@ -139,7 +139,7 @@ class FuncInNode(Node):
         self.func_name = self.add_attribute('func_name',StringTopic,editor_type='text')
         self.outs = self.add_attribute('outs',ListTopic,editor_type='list')
 
-    def init_node(self):
+
         self.outs.add_validator(ListTopic.unique_validator)
         self.outs.on_insert.add_auto(self.on_output_added)
         self.outs.on_pop.add_auto(self.on_output_removed)
@@ -209,7 +209,7 @@ class FuncOutNode(Node):
         self.func_name = self.add_attribute('func_name',StringTopic,editor_type='text')
         self.ins = self.add_attribute('ins',ListTopic,editor_type='list')
 
-    def init_node(self):
+
         self.ins.add_validator(ListTopic.unique_validator)
         self.ins.on_insert.add_auto(self.on_input_added)
         self.ins.on_pop.add_auto(self.on_input_removed)

--- a/extensions/grapycal_builtin/grapycal_builtin/procedural/limiterNode.py
+++ b/extensions/grapycal_builtin/grapycal_builtin/procedural/limiterNode.py
@@ -18,8 +18,8 @@ class LimiterNode(Node):
         self.reduce_factor = self.add_attribute('reduce_factor', IntTopic, 10, editor_type='int')
         self.time_span = self.add_attribute('time_span', FloatTopic, 0.2, editor_type='float')
 
-    def init_node(self):
-        super().init_node()
+
+        
         self.value = None
         self.has_value = False
         self.lock = Lock()

--- a/extensions/grapycal_builtin/grapycal_builtin/procedural/procedureNode.py
+++ b/extensions/grapycal_builtin/grapycal_builtin/procedural/procedureNode.py
@@ -18,7 +18,7 @@ class ProcedureNode(Node):
         self.css_classes.append('fit-content')
         self.icon_path.set('steps')
 
-    def init_node(self):
+
         self.steps.add_validator(ListTopic.unique_validator)
         self.steps.on_insert.add_auto(self.add_step)
         self.steps.on_pop.add_auto(self.remove_step)

--- a/extensions/grapycal_myext/__init__.py
+++ b/extensions/grapycal_myext/__init__.py
@@ -1,4 +1,5 @@
 from grapycal import Node, Edge, InputPort
+from grapycal.extension.utils import NodeInfo
 from grapycal.sobjects.controls.buttonControl import ButtonControl
 from grapycal.sobjects.controls.optionControl import OptionControl
 from grapycal.sobjects.controls.textControl import TextControl
@@ -42,19 +43,31 @@ class TestDefaultNode(Node):
     def double_click(self):
         self.out_port.push_data(self.in_port.get_one_data())
 
-class OptionControlExampleNode(Node):
+class BeforeNode(Node):
     category = 'function'
 
     def build_node(self):
         self.label.set('Select a fruit')
-        self.option_control = self.add_option_control(
-            options=['apple','banana','orange'],
-            value='apple',
-            label='Fruit'
-        )
+        self.option_control = self.add_option_control(options=['apple','banana'],value='apple',name='opt')
         self.out_port = self.add_out_port('out')
 
     def init_node(self):
+        self.option_control.on_set += self.option_changed
+
+    def restore_from_version(self, version: str, old: NodeInfo):
+        super().restore_from_version(version, old)
+        self.restore_attributes('opt')
+
+    def option_changed(self,value:str):
+        self.out_port.push_data(value)
+
+class AfterNode(Node):
+    category = 'function'
+
+    def create(self):
+        self.label.set('Select a fruit')
+        self.option_control = self.add_option_control(options=['apple','banana'],value='apple',name='opt')
+        self.out_port = self.add_out_port('out')
         self.option_control.on_set += self.option_changed
 
     def option_changed(self,value:str):

--- a/frontend/src/sobjects/editor.ts
+++ b/frontend/src/sobjects/editor.ts
@@ -88,8 +88,9 @@ export class Editor extends CompSObject{
         this.link(GlobalEventDispatcher.instance.onKeyDown.slice('ctrl c'),this.copy)
         this.link(GlobalEventDispatcher.instance.onKeyDown.slice('ctrl v'),this.paste)
         this.link(GlobalEventDispatcher.instance.onKeyDown.slice('ctrl x'),this.cut)
+        this.link(GlobalEventDispatcher.instance.onKeyDown.slice('Delete'),this.delete)
+        this.link(GlobalEventDispatcher.instance.onKeyDown.slice('Backspace'),this.delete)
     }
-    
 
     private lastUpdatePortNearMouse = 0
     private mouseMove(e: MouseEvent){
@@ -248,7 +249,19 @@ export class Editor extends CompSObject{
             // save to clipboard
             let text = JSON.stringify(data)
             navigator.clipboard.writeText(text)
-            this.objectsync.emit('delete',{ids:selectedIds})
+            this.makeRequest('delete',{ids:selectedIds})
         })
+    }
+
+    private delete(){
+        if(document.activeElement != document.body) return;
+        let selectedIds = []
+        for(let s of Workspace.instance.selection.selected){
+            let o = s.object
+            if(o instanceof Node || o instanceof Edge){
+                selectedIds.push(o.id);
+            }
+        }
+        this.makeRequest('delete',{ids:selectedIds})
     }
 }

--- a/frontend/src/sobjects/workspace.ts
+++ b/frontend/src/sobjects/workspace.ts
@@ -55,25 +55,11 @@ export class Workspace extends CompSObject{
             if(GlobalEventDispatcher.instance.isKeyDown('Shift')) return;
             this.selection.clearSelection()
         })
-        GlobalEventDispatcher.instance.onKeyDown.add('Delete',this.deletePressed.bind(this))
-        GlobalEventDispatcher.instance.onKeyDown.add('Backspace',this.deletePressed.bind(this))
 
         new Footer()
         Footer.setStatus('Workspace loaded. Have fun!')
     }
-    private deletePressed(){
-        // check if nothing in document is focused
-        if(document.activeElement != document.body) return;
-        
-        let selectedIds = []
-        for(let s of this.selection.selected){
-            let o = s.object
-            if(o instanceof Node || o instanceof Edge){
-                selectedIds.push(o.id);
-            }
-        }
-        this.objectsync.emit('delete',{ids:selectedIds})
-    }
+
     public openWorkspace(path:string){
         this.objectsync.emit('open_workspace',{path:path})
     }


### PR DESCRIPTION
Did 2 major changes on the node definition API, hoping to make development of nodes easier.

1. Merge build_node() and init_node() into a single method create(). No more need to separate initialization code into two methods.
2. Restore all attributes and controls by default. This change is based on the observation that node types usually need to restore all its attributes and controls. 

The restore_from_version() method is renamed to restore(). It enables one to manually write the logic of restoration.

Extension writers are encouraged to change their code the new format because it's much easier to use. While I tried my best for backward compatibility, there are still possibilities that node types with the old format can't load perfectly after this merge.

For example:

```python
# old format
class BeforeNode(Node):
    category = 'function'

    def build_node(self):
        self.label.set('Select a fruit')
        self.option_control = self.add_option_control(options=['apple','banana'],value='apple',name='opt')
        self.out_port = self.add_out_port('out')

    def init_node(self):
        self.option_control.on_set += self.option_changed

    def restore_from_version(self, version: str, old: NodeInfo):
        super().restore_from_version(version, old)
        self.restore_attributes('opt')

    def option_changed(self,value:str):
        self.out_port.push_data(value)

# new format
class AfterNode(Node):
    category = 'function'

    def create(self):
        self.label.set('Select a fruit')
        self.option_control = self.add_option_control(options=['apple','banana'],value='apple',name='opt')
        self.out_port = self.add_out_port('out')
        self.option_control.on_set += self.option_changed

    def option_changed(self,value:str):
        self.out_port.push_data(value)
```